### PR TITLE
make colors go fast

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,36 @@
+const ESC = "\u001B[";
+const END = "m";
+
 // Intentionally not using template literal for performance.
-const format = (startCode, endCode) => string => '\u001B[' + startCode + 'm' + string + '\u001B[' + endCode + 'm';
+const format = (startCode, endCode, string) =>
+	ESC + startCode + END + string + ESC + endCode + END;
 
-export const reset = format(0, 0);
-export const bold = format(1, 22);
-export const dim = format(2, 22);
-export const italic = format(3, 23);
-export const underline = format(4, 24);
-export const overline = format(53, 55);
-export const inverse = format(7, 27);
-export const hidden = format(8, 28);
-export const strikethrough = format(9, 29);
+export const reset = format.bind(void 0, 0, 0);
+export const bold = format.bind(void 0, 1, 22);
+export const dim = format.bind(void 0, 2, 22);
+export const italic = format.bind(void 0, 3, 23);
+export const underline = format.bind(void 0, 4, 24);
+export const overline = format.bind(void 0, 53, 55);
+export const inverse = format.bind(void 0, 7, 27);
+export const hidden = format.bind(void 0, 8, 28);
+export const strikethrough = format.bind(void 0, 9, 29);
 
-export const black = format(30, 39);
-export const red = format(31, 39);
-export const green = format(32, 39);
-export const yellow = format(33, 39);
-export const blue = format(34, 39);
-export const magenta = format(35, 39);
-export const cyan = format(36, 39);
-export const white = format(37, 39);
-export const gray = format(90, 39);
+export const black = format.bind(void 0, 30, 39);
+export const red = format.bind(void 0, 31, 39);
+export const green = format.bind(void 0, 32, 39);
+export const yellow = format.bind(void 0, 33, 39);
+export const blue = format.bind(void 0, 34, 39);
+export const magenta = format.bind(void 0, 35, 39);
+export const cyan = format.bind(void 0, 36, 39);
+export const white = format.bind(void 0, 37, 39);
+export const gray = format.bind(void 0, 90, 39);
 
-export const bgBlack = format(40, 49);
-export const bgRed = format(41, 49);
-export const bgGreen = format(42, 49);
-export const bgYellow = format(43, 49);
-export const bgBlue = format(44, 49);
-export const bgMagenta = format(45, 49);
-export const bgCyan = format(46, 49);
-export const bgWhite = format(47, 49);
-export const bgGray = format(100, 49);
+export const bgBlack = format.bind(void 0, 40, 49);
+export const bgRed = format.bind(void 0, 41, 49);
+export const bgGreen = format.bind(void 0, 42, 49);
+export const bgYellow = format.bind(void 0, 43, 49);
+export const bgBlue = format.bind(void 0, 44, 49);
+export const bgMagenta = format.bind(void 0, 45, 49);
+export const bgCyan = format.bind(void 0, 46, 49);
+export const bgWhite = format.bind(void 0, 47, 49);
+export const bgGray = format.bind(void 0, 100, 49);


### PR DESCRIPTION
Further optimizations that matter:

- No memory allocations (i.e. malloc is not even included in runtime – colors don't need memory)
- Less bytecodes (more room for critical software than colors)
- Less ticks (more CPU time for more important things than colors)
- 0.05-1% faster (less cat videos to watch while printing colors)

Diff of processed profiler with `node --prof` and `node --prof-process` to show no malloc include and drastically less ticks that matter:

```diff
1c1
< Statistical profiling result from yoctocolors.log, (173 ticks, 1 unaccounted, 0 excluded).
---
> Statistical profiling result from plankcolors.log, (72 ticks, 0 unaccounted, 0 excluded).
5,8c5,7
<       6    3.5%          /usr/lib/system/libsystem_pthread.dylib
<       3    1.7%          /usr/lib/system/libsystem_platform.dylib
<       1    0.6%          /usr/lib/system/libsystem_malloc.dylib
<       1    0.6%          /usr/lib/system/libsystem_kernel.dylib
---
>       4    5.6%          /usr/lib/system/libsystem_pthread.dylib
>       2    2.8%          /usr/lib/system/libsystem_kernel.dylib
>       1    1.4%          /usr/lib/system/libsystem_platform.dylib
[snip]
```

You can diff the bytecode yourself with `node --print-bytecode` if you have time, while you're printing color output in your terminal.

Next PR will rename to plankcolors 😼 