### PR TITLE
fastocolors

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,78 @@
+import {Suite} from '@jonahsnider/benchmark';
+import ansi from 'ansi-colors';
+import cliColor from 'cli-color';
+import * as colorette from 'colorette';
+import kleur from 'kleur';
+// eslint-disable-next-line node/file-extension-in-import
+import * as kleurColors from 'kleur/colors';
+import * as nanocolors from 'nanocolors';
+import picocolors from 'picocolors';
+import * as yoctocolors from './index.js';
+
+const suite = new Suite('simple', {
+	warmup: {trials: 10_000_000},
+	run: {trials: 1_000_000},
+});
+
+// eslint-disable-next-line no-unused-vars
+let out;
+
+suite
+	.addTest('yoctocolors', () => {
+		out = yoctocolors.red('Add plugin to use time limit');
+		out = yoctocolors.green('Add plugin to use time limit');
+		out = yoctocolors.blue('Add plugin to use time limit');
+	})
+	.addTest('cli-color', () => {
+		out = cliColor.red('Add plugin to use time limit');
+		out = cliColor.green('Add plugin to use time limit');
+		out = cliColor.blue('Add plugin to use time limit');
+	})
+	.addTest('ansi-colors', () => {
+		out = ansi.red('Add plugin to use time limit');
+		out = ansi.green('Add plugin to use time limit');
+		out = ansi.blue('Add plugin to use time limit');
+	})
+	.addTest('kleur', () => {
+		out = kleur.red('Add plugin to use time limit');
+		out = kleur.green('Add plugin to use time limit');
+		out = kleur.blue('Add plugin to use time limit');
+	})
+	.addTest('kleur/colors', () => {
+		out = kleurColors.red('Add plugin to use time limit');
+		out = kleurColors.green('Add plugin to use time limit');
+		out = kleurColors.blue('Add plugin to use time limit');
+	})
+	.addTest('colorette', () => {
+		out = colorette.red('Add plugin to use time limit');
+		out = colorette.green('Add plugin to use time limit');
+		out = colorette.blue('Add plugin to use time limit');
+	})
+	.addTest('nanocolors', () => {
+		out = nanocolors.red('Add plugin to use time limit');
+		out = nanocolors.green('Add plugin to use time limit');
+		out = nanocolors.blue('Add plugin to use time limit');
+	})
+	.addTest('picocolors', () => {
+		out = picocolors.red('Add plugin to use time limit');
+		out = picocolors.green('Add plugin to use time limit');
+		out = picocolors.blue('Add plugin to use time limit');
+	});
+
+const results = await suite.run();
+
+const table = [...results]
+	// Convert median execution time to mean ops/sec
+	.map(([library, histogram]) => [
+		library,
+		Math.round(1e9 / histogram.percentile(50)),
+	])
+	// Sort fastest to slowest
+	.sort(([, a], [, b]) => b - a)
+	// Convert to object for console.table
+	.map(([library, opsPerSec]) => ({
+		library,
+		'ops/sec': opsPerSec.toLocaleString(),
+	}));
+
+console.table(table);

--- a/index.js
+++ b/index.js
@@ -3,35 +3,41 @@ import tty from 'node:tty';
 // TODO: Use a better method when it's added to Node.js (https://github.com/nodejs/node/pull/40240)
 const hasColors = tty.WriteStream.prototype.hasColors();
 
-// Intentionally not using template literal for performance.
-const format = (startCode, endCode) => hasColors ? string => '\u001B[' + startCode + 'm' + string + '\u001B[' + endCode + 'm' : string => string;
+const format = hasColors
+	? function (string) {
+		// Intentionally not using template literal for performance.
+		return (
+			'\u001B[' + this.start + 'm' + string + '\u001B[' + this.end + 'm'
+		);
+	}
+	: string => string;
 
-export const reset = format(0, 0);
-export const bold = format(1, 22);
-export const dim = format(2, 22);
-export const italic = format(3, 23);
-export const underline = format(4, 24);
-export const overline = format(53, 55);
-export const inverse = format(7, 27);
-export const hidden = format(8, 28);
-export const strikethrough = format(9, 29);
+export const reset = format.bind({start: 0, end: 0});
+export const bold = format.bind({start: 1, end: 22});
+export const dim = format.bind({start: 2, end: 22});
+export const italic = format.bind({start: 3, end: 23});
+export const underline = format.bind({start: 4, end: 24});
+export const overline = format.bind({start: 53, end: 55});
+export const inverse = format.bind({start: 7, end: 27});
+export const hidden = format.bind({start: 8, end: 28});
+export const strikethrough = format.bind({start: 9, end: 29});
 
-export const black = format(30, 39);
-export const red = format(31, 39);
-export const green = format(32, 39);
-export const yellow = format(33, 39);
-export const blue = format(34, 39);
-export const magenta = format(35, 39);
-export const cyan = format(36, 39);
-export const white = format(37, 39);
-export const gray = format(90, 39);
+export const black = format.bind({start: 30, end: 39});
+export const red = format.bind({start: 31, end: 39});
+export const green = format.bind({start: 32, end: 39});
+export const yellow = format.bind({start: 33, end: 39});
+export const blue = format.bind({start: 34, end: 39});
+export const magenta = format.bind({start: 35, end: 39});
+export const cyan = format.bind({start: 36, end: 39});
+export const white = format.bind({start: 37, end: 39});
+export const gray = format.bind({start: 90, end: 39});
 
-export const bgBlack = format(40, 49);
-export const bgRed = format(41, 49);
-export const bgGreen = format(42, 49);
-export const bgYellow = format(43, 49);
-export const bgBlue = format(44, 49);
-export const bgMagenta = format(45, 49);
-export const bgCyan = format(46, 49);
-export const bgWhite = format(47, 49);
-export const bgGray = format(100, 49);
+export const bgBlack = format.bind({start: 40, end: 49});
+export const bgRed = format.bind({start: 41, end: 49});
+export const bgGreen = format.bind({start: 42, end: 49});
+export const bgYellow = format.bind({start: 43, end: 49});
+export const bgBlue = format.bind({start: 44, end: 49});
+export const bgMagenta = format.bind({start: 45, end: 49});
+export const bgCyan = format.bind({start: 46, end: 49});
+export const bgWhite = format.bind({start: 47, end: 49});
+export const bgGray = format.bind({start: 100, end: 49});

--- a/package.json
+++ b/package.json
@@ -43,9 +43,17 @@
 		"text"
 	],
 	"devDependencies": {
+		"@jonahsnider/benchmark": "^3.0.1",
+		"ansi-colors": "^4.1.1",
 		"ava": "^3.15.0",
+		"chalk": "^4.1.2",
+		"cli-color": "^2.0.1",
+		"colorette": "^2.0.16",
+		"kleur": "^4.1.4",
+		"nanocolors": "^0.2.13",
+		"picocolors": "^1.0.0",
 		"tsd": "^0.17.0",
-		"xo": "^0.44.0"
+		"xo": "^0.46.4"
 	},
 	"ava": {
 		"environmentVariables": {


### PR DESCRIPTION
# fastocolors: yoctocolors but faster

I spent a few hours testing out several ways to increase performance and settled on the fastest possible way: passing color codes as the `this` context in a bound function.

I also added benchmarks (disclaimer: I wrote [the benchmark library](https://benchmark.jonah.pw/) because I was fed-up with [how ancient benchmark.js is](https://github.com/bestiejs/benchmark.js/blob/42f3b732bac3640eddb3ae5f50e445f3141016fd/benchmark.js#L179-L180)) since the ones referenced in the README have since been deleted from nanocolors.

```js
const format = hasColors
	? function (string) {
		// Intentionally not using template literal for performance.
		return (
			'\u001B[' + this.start + 'm' + string + '\u001B[' + this.end + 'm'
		);
	}
	: string => string;

export const reset = format.bind({start: 0, end: 0});
```

This results in a slightly larger bundle size although the code will gzip very well.
You could rename the `start`/`end` properties to `s`/`e` or `l`/`r` if uncompressed size is important to you.

There are a few reasons using `.bind()` has this increase on performance:

## Benchmarks

### No warmup

This benchmark had 0 warmup trials and 1M measurement trials.
This is an interesting benchmark because the bound function performs considerably better than the original function.

The reason for this is because the original code created a new function for each color.
A warmup period would allow V8 to optimize each color function very well, but we're only doing 1M trials per function which is not enough for that to happen.

The bound function is using the same function for each color but with the `this` context set with each color's codes.
To V8 this is treated as a single function implementation which means calling `red()`, `green()`, and `blue()` 1M times each is treated as calling `format()` 3M times.

3M > 1M, so the bound function is optimized better.

```text
┌─────────┬──────────────────────┬─────────────┐
│ (index) │       library        │   ops/sec   │
├─────────┼──────────────────────┼─────────────┤
│    0    │      'this PR'       │ '8,264,463' │ a 6.6% performance improvement
│    1    │ 'yoctocolors on npm' │ '7,751,938' │
│    2    │     'nanocolors'     │ '7,575,758' │
│    3    │     'picocolors'     │ '5,714,286' │
│    4    │     'colorette'      │ '5,464,481' │
│    5    │    'kleur/colors'    │ '5,000,000' │
│    6    │       'kleur'        │ '3,717,472' │
│    7    │    'ansi-colors'     │ '1,303,781' │
│    8    │     'cli-color'      │  '387,747'  │
└─────────┴──────────────────────┴─────────────┘
```

### With warmup

This is a "fairer" benchmark since each implementation is given sufficient opportunity to be optimized.
This benchmark had 10M warmup trials and 1M measurement trials.

The performance difference between the current implementation and the bound function is much closer now, but there is still a slight improvement from the bound function.

```text
┌─────────┬──────────────────────┬─────────────┐
│ (index) │       library        │   ops/sec   │
├─────────┼──────────────────────┼─────────────┤
│    0    │      'this PR'       │ '8,474,576' │ a 2.5% performance improvement
│    1    │ 'yoctocolors on npm' │ '8,264,463' │
│    2    │     'nanocolors'     │ '7,874,016' │
│    3    │     'picocolors'     │ '5,780,347' │
│    4    │     'colorette'      │ '5,617,978' │
│    5    │    'kleur/colors'    │ '5,405,405' │
│    6    │       'kleur'        │ '3,787,879' │
│    7    │    'ansi-colors'     │ '1,344,086' │
│    8    │     'cli-color'      │  '396,354'  │
└─────────┴──────────────────────┴─────────────┘
```

## Other things I tried

### Converting numbers to strings

I tried this for all implementations.
It resulted in either a slight slowdown or no change.

### Binding `this` as an array

```js
export const reset = format.bind([0, 0]);
```

This results in cleaner code and a smaller bundle size but is a fair deal slower.
Probably due to passing around a whole array instance instead of a plain object.

### Binding with parameters

```js
const format = hasColors
  ? function (start, end, string) {
      // Intentionally not using template literal for performance.
      return "\u001B[" + start + "m" + string + "\u001B[" + end + "m";
    }
  : (string) => string;

export const reset = format.bind(null, 0, 0);
```

Slightly slower than `.bind()` with `this` context.
This `.bind(this)` is consistently faster than `.bind(null, ...params)` in most projects.

### Code generation

```js
const identity = (string) => string;

const format = hasColors
  ? (startCode, endCode) =>
      // eslint-disable-next-line no-new-func
      new Function("string", `return '\u001B[${startCode}m' + string + '\u001B[${endCode}m';`)
  : () => identity;

export const reset = format(0, 0);
```

When calling the same function over and over (ex. `yoctocolors.red()`) V8 optimizes it very well.
Calling a set of functions (ex. `.red()`, `.green()`, `.blue()`) is slower than `.bind()` with `this` context.

Most users aren't going to call a single function over and over though.
I decided not to use this as we should be optimizing for the most common use case.