### PR TITLE
Add benchmarks

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { Suite } from "@jonahsnider/benchmark";
+import ansi from "ansi-colors";
+import chalk from "chalk";
+import cliColor from "cli-color";
+import * as colorette from "colorette";
+import kleur from "kleur";
+// eslint-disable-next-line node/file-extension-in-import
+import * as kleurColors from "kleur/colors";
+import * as nanocolors from "nanocolors";
+import picocolors from "picocolors";
+import * as yoctocolors from "./index.js";
+
+const suite = new Suite("simple", {
+	warmup: { trials: 10_000_000 },
+	run: { trials: 1_000_000 },
+});
+
+// eslint-disable-next-line no-unused-vars
+let out;
+
+suite
+	.addTest("yoctocolors", () => {
+		out = yoctocolors.red("Add plugin to use time limit");
+		out = yoctocolors.green("Add plugin to use time limit");
+		out = yoctocolors.blue("Add plugin to use time limit");
+	})
+	.addTest("cli-color", () => {
+		out = cliColor.red("Add plugin to use time limit");
+		out = cliColor.green("Add plugin to use time limit");
+		out = cliColor.blue("Add plugin to use time limit");
+	})
+	.addTest("ansi-colors", () => {
+		out = ansi.red("Add plugin to use time limit");
+		out = ansi.green("Add plugin to use time limit");
+		out = ansi.blue("Add plugin to use time limit");
+	})
+	.addTest("chalk", () => {
+		out = chalk.red("Add plugin to use time limit");
+		out = chalk.green("Add plugin to use time limit");
+		out = chalk.blue("Add plugin to use time limit");
+	})
+	.addTest("kleur", () => {
+		out = kleur.red("Add plugin to use time limit");
+		out = kleur.green("Add plugin to use time limit");
+		out = kleur.blue("Add plugin to use time limit");
+	})
+	.addTest("kleur/colors", () => {
+		out = kleurColors.red("Add plugin to use time limit");
+		out = kleurColors.green("Add plugin to use time limit");
+		out = kleurColors.blue("Add plugin to use time limit");
+	})
+	.addTest("colorette", () => {
+		out = colorette.red("Add plugin to use time limit");
+		out = colorette.green("Add plugin to use time limit");
+		out = colorette.blue("Add plugin to use time limit");
+	})
+	.addTest("nanocolors", () => {
+		out = nanocolors.red("Add plugin to use time limit");
+		out = nanocolors.green("Add plugin to use time limit");
+		out = nanocolors.blue("Add plugin to use time limit");
+	})
+	.addTest("picocolors", () => {
+		out = picocolors.red("Add plugin to use time limit");
+		out = picocolors.green("Add plugin to use time limit");
+		out = picocolors.blue("Add plugin to use time limit");
+	});
+
+const results = await suite.run();
+
+const table = [...results]
+	// Convert median execution time to mean ops/sec
+	.map(([library, histogram]) => [
+		library,
+		Math.round(1e9 / histogram.percentile(50)),
+	])
+	// Sort fastest to slowest
+	.sort(([, a], [, b]) => b - a)
+	// Convert to object for console.table
+	.map(([library, opsPerSec]) => ({
+		library,
+		"ops/sec": opsPerSec.toLocaleString(),
+	}));
+
+console.table(table);

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,70 +1,70 @@
 #!/usr/bin/env node
 
-import { Suite } from "@jonahsnider/benchmark";
-import ansi from "ansi-colors";
-import chalk from "chalk";
-import cliColor from "cli-color";
-import * as colorette from "colorette";
-import kleur from "kleur";
+import {Suite} from '@jonahsnider/benchmark';
+import ansi from 'ansi-colors';
+import chalk from 'chalk';
+import cliColor from 'cli-color';
+import * as colorette from 'colorette';
+import kleur from 'kleur';
 // eslint-disable-next-line node/file-extension-in-import
-import * as kleurColors from "kleur/colors";
-import * as nanocolors from "nanocolors";
-import picocolors from "picocolors";
-import * as yoctocolors from "./index.js";
+import * as kleurColors from 'kleur/colors';
+import * as nanocolors from 'nanocolors';
+import picocolors from 'picocolors';
+import * as yoctocolors from './index.js';
 
-const suite = new Suite("simple", {
-	warmup: { trials: 10_000_000 },
-	run: { trials: 1_000_000 },
+const suite = new Suite('simple', {
+	warmup: {trials: 10_000_000},
+	run: {trials: 1_000_000},
 });
 
 // eslint-disable-next-line no-unused-vars
 let out;
 
 suite
-	.addTest("yoctocolors", () => {
-		out = yoctocolors.red("Add plugin to use time limit");
-		out = yoctocolors.green("Add plugin to use time limit");
-		out = yoctocolors.blue("Add plugin to use time limit");
+	.addTest('yoctocolors', () => {
+		out = yoctocolors.red('Add plugin to use time limit');
+		out = yoctocolors.green('Add plugin to use time limit');
+		out = yoctocolors.blue('Add plugin to use time limit');
 	})
-	.addTest("cli-color", () => {
-		out = cliColor.red("Add plugin to use time limit");
-		out = cliColor.green("Add plugin to use time limit");
-		out = cliColor.blue("Add plugin to use time limit");
+	.addTest('cli-color', () => {
+		out = cliColor.red('Add plugin to use time limit');
+		out = cliColor.green('Add plugin to use time limit');
+		out = cliColor.blue('Add plugin to use time limit');
 	})
-	.addTest("ansi-colors", () => {
-		out = ansi.red("Add plugin to use time limit");
-		out = ansi.green("Add plugin to use time limit");
-		out = ansi.blue("Add plugin to use time limit");
+	.addTest('ansi-colors', () => {
+		out = ansi.red('Add plugin to use time limit');
+		out = ansi.green('Add plugin to use time limit');
+		out = ansi.blue('Add plugin to use time limit');
 	})
-	.addTest("chalk", () => {
-		out = chalk.red("Add plugin to use time limit");
-		out = chalk.green("Add plugin to use time limit");
-		out = chalk.blue("Add plugin to use time limit");
+	.addTest('chalk', () => {
+		out = chalk.red('Add plugin to use time limit');
+		out = chalk.green('Add plugin to use time limit');
+		out = chalk.blue('Add plugin to use time limit');
 	})
-	.addTest("kleur", () => {
-		out = kleur.red("Add plugin to use time limit");
-		out = kleur.green("Add plugin to use time limit");
-		out = kleur.blue("Add plugin to use time limit");
+	.addTest('kleur', () => {
+		out = kleur.red('Add plugin to use time limit');
+		out = kleur.green('Add plugin to use time limit');
+		out = kleur.blue('Add plugin to use time limit');
 	})
-	.addTest("kleur/colors", () => {
-		out = kleurColors.red("Add plugin to use time limit");
-		out = kleurColors.green("Add plugin to use time limit");
-		out = kleurColors.blue("Add plugin to use time limit");
+	.addTest('kleur/colors', () => {
+		out = kleurColors.red('Add plugin to use time limit');
+		out = kleurColors.green('Add plugin to use time limit');
+		out = kleurColors.blue('Add plugin to use time limit');
 	})
-	.addTest("colorette", () => {
-		out = colorette.red("Add plugin to use time limit");
-		out = colorette.green("Add plugin to use time limit");
-		out = colorette.blue("Add plugin to use time limit");
+	.addTest('colorette', () => {
+		out = colorette.red('Add plugin to use time limit');
+		out = colorette.green('Add plugin to use time limit');
+		out = colorette.blue('Add plugin to use time limit');
 	})
-	.addTest("nanocolors", () => {
-		out = nanocolors.red("Add plugin to use time limit");
-		out = nanocolors.green("Add plugin to use time limit");
-		out = nanocolors.blue("Add plugin to use time limit");
+	.addTest('nanocolors', () => {
+		out = nanocolors.red('Add plugin to use time limit');
+		out = nanocolors.green('Add plugin to use time limit');
+		out = nanocolors.blue('Add plugin to use time limit');
 	})
-	.addTest("picocolors", () => {
-		out = picocolors.red("Add plugin to use time limit");
-		out = picocolors.green("Add plugin to use time limit");
-		out = picocolors.blue("Add plugin to use time limit");
+	.addTest('picocolors', () => {
+		out = picocolors.red('Add plugin to use time limit');
+		out = picocolors.green('Add plugin to use time limit');
+		out = picocolors.blue('Add plugin to use time limit');
 	});
 
 const results = await suite.run();
@@ -80,7 +80,7 @@ const table = [...results]
 	// Convert to object for console.table
 	.map(([library, opsPerSec]) => ({
 		library,
-		"ops/sec": opsPerSec.toLocaleString(),
+		'ops/sec': opsPerSec.toLocaleString(),
 	}));
 
 console.table(table);

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 import {Suite} from '@jonahsnider/benchmark';
 import ansi from 'ansi-colors';
 import chalk from 'chalk';

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"nanocolors": "^0.2.13",
 		"picocolors": "^1.0.0",
 		"tsd": "^0.17.0",
-		"xo": "^0.44.0"
+		"xo": "^0.47.0"
 	},
 	"ava": {
 		"environmentVariables": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,15 @@
 		"text"
 	],
 	"devDependencies": {
+		"@jonahsnider/benchmark": "^5.0.0",
+		"ansi-colors": "^4.1.1",
 		"ava": "^3.15.0",
+		"chalk": "^5.0.0",
+		"cli-color": "^2.0.1",
+		"colorette": "^2.0.16",
+		"kleur": "^4.1.4",
+		"nanocolors": "^0.2.13",
+		"picocolors": "^1.0.0",
 		"tsd": "^0.17.0",
 		"xo": "^0.44.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -75,14 +75,24 @@ Yes
 
 ## Benchmark
 
-```
-❯ ./test/simple-benchmark.js
-nanocolors    31508276 ops/sec
-picocolors    32524769 ops/sec
-yoctocolors   132894792 ops/sec
+```sh
+$ ./benchmark.js
+┌─────────┬────────────────┬─────────────┐
+│ (index) │    library     │   ops/sec   │
+├─────────┼────────────────┼─────────────┤
+│    0    │ 'yoctocolors'  │ '8,771,930' │
+│    1    │  'nanocolors'  │ '6,896,552' │
+│    2    │  'colorette'   │ '6,172,840' │
+│    3    │  'picocolors'  │ '6,060,606' │
+│    4    │ 'kleur/colors' │ '5,263,158' │
+│    5    │    'chalk'     │ '4,484,305' │
+│    6    │    'kleur'     │ '3,731,343' │
+│    7    │ 'ansi-colors'  │ '1,283,697' │
+│    8    │  'cli-color'   │  '393,236'  │
+└─────────┴────────────────┴─────────────┘
 ```
 
-*Benchmark from [`nanocolors`](https://github.com/ai/nanocolors/blob/main/test/simple-benchmark.js)*
+*See [benchmark.js](./benchmark.js).*
 
 ## FAQ
 


### PR DESCRIPTION
Extracted from #7

> I also added benchmarks (disclaimer: I wrote [the benchmark library](https://benchmark.jonah.pw/) because I was fed-up with [how ancient benchmark.js is](https://github.com/bestiejs/benchmark.js/blob/42f3b732bac3640eddb3ae5f50e445f3141016fd/benchmark.js#L179-L180)) since the ones referenced in the README have since been deleted from nanocolors.

The benchmark values I added to the README were run on my MacBook Pro (16-inch, 2019). Feel free to run them locally if you want to verify the results. The benchmarks took 1m19s from start to finish.