### PR TITLE
Update FAQ

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ $ ./benchmark.js
 
 ### What is yocto?
 
-[It's the smallest official unit prefix in the metric system.](https://en.wikipedia.org/wiki/Yocto-) Much smaller than nano.
+[It was the smallest official unit prefix in the metric system until 2022.](https://en.wikipedia.org/wiki/Yocto-) Much smaller than nano.
 
 ## Related
 


### PR DESCRIPTION
Since 2022, there are new [SI prefixes](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes) so yocto is no longer the smallest one defined 😉.